### PR TITLE
Don't crash if cache directory contents can't be listed

### DIFF
--- a/library/src/main/java/no/finntech/capturandro/Capturandro.java
+++ b/library/src/main/java/no/finntech/capturandro/Capturandro.java
@@ -158,11 +158,14 @@ public class Capturandro {
                             return filename.startsWith("capturando-") && filename.endsWith(".jpg");
                         }
                     });
-                    for (File file : files) {
-                        try {
-                            file.delete();
-                        } catch (Exception e) {
-                            e.printStackTrace();
+                    // If READ_EXTERNAL_STORAGE permission isn't granted, files might be null
+                    if (files != null) {
+                        for (File file : files) {
+                            try {
+                                file.delete();
+                            } catch (Exception e) {
+                                e.printStackTrace();
+                            }
                         }
                     }
                     return null;


### PR DESCRIPTION
Although the API docs say it isn't required, some devices refuse to list files in external cache dir until READ_EXTERNAL_STORAGE permission is granted. Capturandro shouldn't crash when this happens.