### PR TITLE
Read EXIF data through input stream

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
-    ext.androidGradleVersion = "4.0.0"
+    ext.androidGradleVersion = '4.0.1'
+    ext.kotlinVersion = '1.3.41'
 
     repositories {
         google()
@@ -8,6 +9,7 @@ buildscript {
 
     dependencies {
         classpath "com.android.tools.build:gradle:${androidGradleVersion}"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
     }
 }
 
@@ -25,6 +27,7 @@ subprojects {
         }
         dependencies {
             classpath "com.android.tools.build:gradle:${androidGradleVersion}"
+            classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
             classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         }
     }
@@ -34,7 +37,6 @@ subprojects {
         jcenter()
         mavenLocal()
     }
-
 }
 
 apply plugin: 'android-reporting'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,12 +3,14 @@ description = 'Capturandro'
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 dependencies {
     implementation('io.reactivex.rxjava2:rxjava:2.1.3')
     implementation('io.reactivex.rxjava2:rxandroid:2.0.1')
     implementation('androidx.legacy:legacy-support-v13:1.0.0')
-    implementation 'androidx.exifinterface:exifinterface:1.3.0-alpha01'
+    implementation('androidx.exifinterface:exifinterface:1.3.0-rc01')
 }
 
 android {

--- a/library/src/main/java/no/finntech/capturandro/OrientationUtil.kt
+++ b/library/src/main/java/no/finntech/capturandro/OrientationUtil.kt
@@ -19,7 +19,7 @@ object OrientationUtil {
             val projection = arrayOf(MediaStore.Images.ImageColumns.ORIENTATION)
             val cursor = contentResolver.query(photoUri, projection, null, null, null)
             if (cursor != null) {
-                if (cursor.moveToFirst()) {
+                if (cursor.moveToFirst() && cursor.columnCount > 0) {
                     return cursor.getInt(0)
                 }
                 cursor.close()

--- a/library/src/main/java/no/finntech/capturandro/OrientationUtil.kt
+++ b/library/src/main/java/no/finntech/capturandro/OrientationUtil.kt
@@ -1,0 +1,77 @@
+package no.finntech.capturandro
+
+import android.content.ContentResolver
+import android.net.Uri
+import android.provider.MediaStore
+import android.util.Log
+import androidx.exifinterface.media.ExifInterface
+import java.io.File
+import java.io.IOException
+
+object OrientationUtil {
+
+    @JvmStatic
+    fun getOrientation(photoUri: Uri, contentResolver: ContentResolver): Int {
+        val exif = readExif(photoUri, contentResolver)
+        if (exif != null) {
+            return getOrientation(exif)
+        } else {
+            val projection = arrayOf(MediaStore.Images.ImageColumns.ORIENTATION)
+            val cursor = contentResolver.query(photoUri, projection, null, null, null)
+            if (cursor != null) {
+                if (cursor.moveToFirst()) {
+                    return cursor.getInt(0)
+                }
+                cursor.close()
+            }
+        }
+        return ExifInterface.ORIENTATION_UNDEFINED
+    }
+
+    @JvmStatic
+    fun getOrientation(exif: ExifInterface?): Int {
+        return exif?.let {
+            val orientation = it.getAttributeInt(
+                    ExifInterface.TAG_ORIENTATION,
+                    ExifInterface.ORIENTATION_UNDEFINED
+            )
+            return when (orientation) {
+                ExifInterface.ORIENTATION_ROTATE_180 -> 180
+                ExifInterface.ORIENTATION_ROTATE_90 -> 90
+                ExifInterface.ORIENTATION_ROTATE_270 -> 270
+                else -> 0
+            }
+        } ?: ExifInterface.ORIENTATION_UNDEFINED
+    }
+
+    private fun readExif(photoUri: Uri, contentResolver: ContentResolver): ExifInterface? {
+        return if (photoUri.scheme == "file") {
+            readExifFromFile(File(photoUri.toString()))
+        } else {
+            readExifFromContent(contentResolver, photoUri)
+        }
+    }
+
+    @JvmStatic
+    fun readExifFromFile(file: File): ExifInterface? {
+        try {
+            return ExifInterface(file)
+        } catch (e: IOException) {
+        }
+        Log.i("Capturandro", "Unable to read exif data from file: ${file.path}")
+        return null
+    }
+
+    private fun readExifFromContent(contentResolver: ContentResolver, photoUri: Uri): ExifInterface? {
+        try {
+            contentResolver.openInputStream(photoUri).use { inputStream ->
+                if (inputStream != null) {
+                    return ExifInterface(inputStream)
+                }
+            }
+        } catch (e: IOException) {
+        }
+        Log.i("Capturandro", "Unable to read exif data from uri: $photoUri")
+        return null
+    }
+}

--- a/sample/src/main/java/no/finntech/capturandro/sample/CapturandroSampleActivity.java
+++ b/sample/src/main/java/no/finntech/capturandro/sample/CapturandroSampleActivity.java
@@ -25,11 +25,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.reactivex.Observable;
-import io.reactivex.functions.Consumer;
 import no.finntech.capturandro.Capturandro;
 import no.finntech.capturandro.CapturandroException;
 
-public class CapturandroSampleActivity extends Activity {
+public class CapturandroSampleActivity extends Activity implements ActivityCompat.OnRequestPermissionsResultCallback {
     private static final int CAMERA_RESULT_CODE = 1;
     private static final int GALLERY_RESULT_CODE = 2;
     private static final int CAMERA_PERMISSION_CODE = 3;


### PR DESCRIPTION
# Why?

I experienced a crash when trying to read the orientation from the cursor. Still not sure how I managed to get the `CursorIndexOutOfBoundsException`, but in any case that's what triggered this update.

# What?

We are currently only looking at the `ExifInterface` when handling the `file://` scheme. I'd like us to prioritise it in any case, instead of going directly through a query with the `content://` uri. The `ContentResolver` will act as a fallback from now on.

This change will take effect when picking from the gallery.

# How?

If we're working with a `File` or a `file://` scheme, the behavior will basically be as before.
When we get a content uri, we'll attempt to read the EXIF data through an `InputStream`. Failing that, we will fall back on the `ContentResolver`, which we are already in the current version.

# Also
* Extracted the orientation and EXIF stuff into a new utility, written in Kotlin.
* Bumped a couple of dependencies
